### PR TITLE
Dynamically calculate timezone offset based on user's timezone

### DIFF
--- a/threads-api/src/threads-api.ts
+++ b/threads-api/src/threads-api.ts
@@ -360,17 +360,19 @@ export class ThreadsAPI {
 
     const base = 'https://i.instagram.com';
     const url = `${base}/api/v1/media/configure_text_only_post/`;
+    const now = new Date();
+    const timezoneOffset = -now.getTimezoneOffset() * 60;
 
     const data = encodeURIComponent(
       JSON.stringify({
         publish_mode: 'text_post',
         text_post_app_info: '{"reply_control":0}',
-        timezone_offset: '-25200',
+        timezone_offset: timezoneOffset.toString(),
         source_type: '4',
         _uid: userID,
         device_id: `${this.deviceID}`,
         caption,
-        upload_id: new Date().getTime(),
+        upload_id: now.getTime(),
         device: {
           manufacturer: 'OnePlus',
           model: 'ONEPLUS+A3010',


### PR DESCRIPTION
The current implementation hard-codes the timezone offset for the PST timezone. This commit introduces changes to dynamically calculate the timezone offset based on the user's timezone. By doing so, we reduce the risk of account bans and detection by adapting to the user's specific time zone. This improves the overall reliability and robustness of the system.

Currently, this mainly affects the ".publish" method to create new threads