### PR TITLE
[api] reduce calls to getUserIDfromUsername

### DIFF
--- a/threads-api/src/threads-api.ts
+++ b/threads-api/src/threads-api.ts
@@ -106,6 +106,7 @@ export type ThreadsAPIOptions = {
   password?: string;
   deviceID?: string;
   device?: AndroidDevice;
+  userID?: string;
 };
 
 export type ThreadsAPIPublishOptions =
@@ -155,6 +156,7 @@ export class ThreadsAPI {
 
     if (options?.deviceID) this.deviceID = options.deviceID;
     this.device = options?.device;
+    this.userID = options?.userID;
   }
 
   _getAppHeaders = () => ({

--- a/threads-api/src/threads-api.ts
+++ b/threads-api/src/threads-api.ts
@@ -511,7 +511,7 @@ export class ThreadsAPI {
       throw new Error('Username or password not set');
     }
 
-    const userID = await this.getUserIDfromUsername(this.username);
+    const userID = await this.getCurrentUserID();
     if (!userID) {
       throw new Error('User ID not found');
     }


### PR DESCRIPTION
For some reason, `getUserIDfromUsername` fails when the calls are coming from AWS EC2 (Insta sends something else that doesn't contain the `userID`)

I have a solution in mind that I'll push a bit later, but for now here's the code to pass optionally `userID` to the constructor and avoid calling `getUserIDfromUsername` in `publish`. That way users can still run the API if they know their userIDs.