### PR TITLE
[api] added instagram as backup for getting userID

### DIFF
--- a/threads-api/src/threads-api.ts
+++ b/threads-api/src/threads-api.ts
@@ -178,11 +178,8 @@ export class ThreadsAPI {
     ...(!!username ? { referer: `https://www.threads.net/@${username}` } : undefined),
   });
 
-  getUserIDfromUsername = async (
-    username: string,
-    options?: AxiosRequestConfig,
-  ): Promise<string | undefined> => {
-    const res = await axios.get(`https://www.instagram.com/${username}`, {
+  getProfilePage = async (url: string, username: string, options?: AxiosRequestConfig) => {
+    const res = await axios.get(`${url}${username}`, {
       ...options,
       httpAgent: this.httpAgent,
       httpsAgent: this.httpsAgent,
@@ -211,8 +208,40 @@ export class ThreadsAPI {
     // remove all newlines from text
     text = text.replace(/\n/g, '');
 
+    return text;
+  };
+
+  getUserIDfromUsernameWithInstagram = async (
+    username: string,
+    options?: AxiosRequestConfig,
+  ): Promise<string | undefined> => {
+    const text = await this.getProfilePage('https://www.instagram.com/', username, options);
+
     const userID: string | undefined = text.match(/"user_id":"(\d+)",/)?.[1];
     const lsdToken: string | undefined = text.match(/"LSD",\[\],{"token":"(\w+)"},\d+\]/)?.[1];
+
+    if (!this.noUpdateLSD && !!lsdToken) {
+      this.fbLSDToken = lsdToken;
+      if (this.verbose) {
+        console.debug('[fbLSDToken] UPDATED', this.fbLSDToken);
+      }
+    }
+
+    return userID;
+  };
+
+  getUserIDfromUsername = async (
+    username: string,
+    options?: AxiosRequestConfig,
+  ): Promise<string | undefined> => {
+    const text = await this.getProfilePage('https://www.threads.net/@', username, options);
+
+    const userID: string | undefined = text.match(/"user_id":"(\d+)"/)?.[1];
+    const lsdToken: string | undefined = text.match(/"LSD",\[\],{"token":"(\w+)"},\d+\]/)?.[1];
+
+    if (!userID) {
+      return this.getUserIDfromUsernameWithInstagram(username, options);
+    }
 
     if (!this.noUpdateLSD && !!lsdToken) {
       this.fbLSDToken = lsdToken;


### PR DESCRIPTION
This should help with AWS blocking. We basically first use the Threads URL, and then the IG if that fails.

It looks like IG is more difficult from AWS, but Threads works, and if Threads profiles go down (like last time), we have a backup with IG.

But I think we should still be looking at other ways to get the `userID`.

PS: it works on my EC2 but still spotty