### PR TITLE
feat: use mrmime instead of mime-types

### DIFF
--- a/threads-api/package.json
+++ b/threads-api/package.json
@@ -47,7 +47,7 @@
     "@swc/cli": "^0.1.62",
     "@swc/core": "^1.3.68",
     "axios": "^1.4.0",
-    "mime-types": "^2.1.35",
+    "mrmime": "^1.0.1",
     "uuid": "^9.0.0"
   },
   "keywords": [

--- a/threads-api/src/threads-api.ts
+++ b/threads-api/src/threads-api.ts
@@ -1,5 +1,5 @@
 import axios, { AxiosRequestConfig } from 'axios';
-import mimeTypes from 'mime-types';
+import mimeTypes from 'mrmime';
 import { v4 as uuidV4 } from 'uuid';
 import {
   POST_URL,


### PR DESCRIPTION
Use `mrmime` instead of `mime-types` since it's 13% the size for same feature set.

https://bundlephobia.com/package/mrmime@1.0.1
https://bundlephobia.com/package/mime-types@2.1.35