### PR TITLE
FIX: NextJS version mismatch in the dependency tree

### DIFF
--- a/threads-web-ui/package.json
+++ b/threads-web-ui/package.json
@@ -16,7 +16,7 @@
     "clsx": "^1.2.1",
     "emotion-reset": "^3.0.1",
     "lucide-react": "^0.258.0",
-    "next": "13.4.4",
+    "next": "^13.4.4",
     "react": "18.2.0",
     "react-dom": "18.2.0",
     "react-is": "^18.2.0",


### PR DESCRIPTION
# Problem: 
- NextJS version mismatch in the root folder of `threads-web-ui` and in the dependency of `react-threads`

![image](https://github.com/junhoyeo/threads-api/assets/86506425/9d41dca6-d4e8-4752-bdb7-623515e1f81f)

## Description: 
- Apparently `react-threads` requires `next@13.4.9` version, but in the [package.json](https://github.com/junhoyeo/threads-api/blob/main/threads-web-ui/package.json) of the `threads-web-ui` only `next@13.4.4` is mentioned.

## Quickfix:
- Altered it to `"next": "^13.4.4"` in the [package.json](https://github.com/junhoyeo/threads-api/blob/main/threads-web-ui/package.json) file.