### PR TITLE
[Fix / Enhancement] Improve `accept-language` header handling

### DIFF
--- a/threads-api/src/threads-api.ts
+++ b/threads-api/src/threads-api.ts
@@ -107,6 +107,7 @@ export type ThreadsAPIOptions = {
   deviceID?: string;
   device?: AndroidDevice;
   userID?: string;
+  locale?: string;
 };
 
 export type ThreadsAPIPublishOptions =
@@ -149,6 +150,8 @@ export class ThreadsAPI {
 
   userID: string | undefined = undefined;
 
+  locale?: string | undefined = undefined;
+
   constructor(options?: ThreadsAPIOptions) {
     if (options?.token) this.token = options.token;
     if (options?.fbLSDToken) this.fbLSDToken = options.fbLSDToken;
@@ -166,6 +169,13 @@ export class ThreadsAPI {
     if (options?.deviceID) this.deviceID = options.deviceID;
     this.device = options?.device;
     this.userID = options?.userID;
+
+    if (options?.locale) {
+      this.locale = options.locale;
+    } else {
+      const detectedLocale: string = Intl.DateTimeFormat().resolvedOptions().locale;
+      this.locale = detectedLocale;
+    }
   }
 
   sign(payload: object | string) {
@@ -322,7 +332,7 @@ export class ThreadsAPI {
     ...this._getAppHeaders(),
     authority: 'www.threads.net',
     accept: '*/*',
-    'accept-language': 'ko',
+    'accept-language': this.locale,
     'cache-control': 'no-cache',
     origin: 'https://www.threads.net',
     pragma: 'no-cache',

--- a/yarn.lock
+++ b/yarn.lock
@@ -2449,13 +2449,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@types/tough-cookie@npm:^4.0.2":
-  version: 4.0.2
-  resolution: "@types/tough-cookie@npm:4.0.2"
-  checksum: e055556ffdaa39ad85ede0af192c93f93f986f4bd9e9426efdc2948e3e2632db3a4a584d4937dbf6d7620527419bc99e6182d3daf2b08685e710f2eda5291905
-  languageName: node
-  linkType: hard
-
 "@types/uuid@npm:^9.0.2":
   version: 9.0.2
   resolution: "@types/uuid@npm:9.0.2"
@@ -2845,13 +2838,6 @@ __metadata:
   version: 2.2.0
   resolution: "binary-extensions@npm:2.2.0"
   checksum: ccd267956c58d2315f5d3ea6757cf09863c5fc703e50fbeb13a7dc849b812ef76e3cf9ca8f35a0c48498776a7478d7b4a0418e1e2b8cb9cb9731f2922aaad7f8
-  languageName: node
-  linkType: hard
-
-"bloks-parser@npm:^0.0.3":
-  version: 0.0.3
-  resolution: "bloks-parser@npm:0.0.3"
-  checksum: ebb9e3b63e27646c755d27697ed7366c222826b25a6adf7f33e7301801f920e90251c265c25264419ec8c72a3fc6241eb28ee15f5817a6ee6342bcb22f613460
   languageName: node
   linkType: hard
 
@@ -5838,13 +5824,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"psl@npm:^1.1.33":
-  version: 1.9.0
-  resolution: "psl@npm:1.9.0"
-  checksum: 20c4277f640c93d393130673f392618e9a8044c6c7bf61c53917a0fddb4952790f5f362c6c730a9c32b124813e173733f9895add8d26f566ed0ea0654b2e711d
-  languageName: node
-  linkType: hard
-
 "pump@npm:^3.0.0":
   version: 3.0.0
   resolution: "pump@npm:3.0.0"
@@ -5855,24 +5834,10 @@ __metadata:
   languageName: node
   linkType: hard
 
-"punycode@npm:^2.1.1":
-  version: 2.3.0
-  resolution: "punycode@npm:2.3.0"
-  checksum: 39f760e09a2a3bbfe8f5287cf733ecdad69d6af2fe6f97ca95f24b8921858b91e9ea3c9eeec6e08cede96181b3bb33f95c6ffd8c77e63986508aa2e8159fa200
-  languageName: node
-  linkType: hard
-
 "pure-rand@npm:^6.0.0":
   version: 6.0.2
   resolution: "pure-rand@npm:6.0.2"
   checksum: 79de33876a4f515d759c48e98d00756bbd916b4ea260cc572d7adfa4b62cace9952e89f0241d0410214554503d25061140fe325c66f845213d2b1728ba8d413e
-  languageName: node
-  linkType: hard
-
-"querystringify@npm:^2.1.1":
-  version: 2.2.0
-  resolution: "querystringify@npm:2.2.0"
-  checksum: 5641ea231bad7ef6d64d9998faca95611ed4b11c2591a8cae741e178a974f6a8e0ebde008475259abe1621cb15e692404e6b6626e927f7b849d5c09392604b15
   languageName: node
   linkType: hard
 
@@ -6047,13 +6012,6 @@ __metadata:
   version: 2.1.1
   resolution: "require-directory@npm:2.1.1"
   checksum: fb47e70bf0001fdeabdc0429d431863e9475e7e43ea5f94ad86503d918423c1543361cc5166d713eaa7029dd7a3d34775af04764bebff99ef413111a5af18c80
-  languageName: node
-  linkType: hard
-
-"requires-port@npm:^1.0.0":
-  version: 1.0.0
-  resolution: "requires-port@npm:1.0.0"
-  checksum: eee0e303adffb69be55d1a214e415cf42b7441ae858c76dfc5353148644f6fd6e698926fc4643f510d5c126d12a705e7c8ed7e38061113bdf37547ab356797ff
   languageName: node
   linkType: hard
 
@@ -6744,17 +6702,14 @@ __metadata:
     "@swc/core": ^1.3.68
     "@types/jest": ^29.5.2
     "@types/node": ^20.4.0
-    "@types/tough-cookie": ^4.0.2
     "@types/uuid": ^9.0.2
     axios: ^1.4.0
     babel-jest: ^29.6.1
-    bloks-parser: ^0.0.3
     commander: ^11.0.0
     dotenv: ^16.3.1
     jest: ^29.6.1
     mrmime: ^1.0.1
     rimraf: ^5.0.1
-    tough-cookie: ^4.1.3
     ts-jest: ^29.1.1
     tslib: ^2.6.0
     typescript: ^5.1.6
@@ -6840,18 +6795,6 @@ __metadata:
   version: 1.1.0
   resolution: "totalist@npm:1.1.0"
   checksum: dfab80c7104a1d170adc8c18782d6c04b7df08352dec452191208c66395f7ef2af7537ddfa2cf1decbdcfab1a47afbbf0dec6543ea191da98c1c6e1599f86adc
-  languageName: node
-  linkType: hard
-
-"tough-cookie@npm:^4.1.3":
-  version: 4.1.3
-  resolution: "tough-cookie@npm:4.1.3"
-  dependencies:
-    psl: ^1.1.33
-    punycode: ^2.1.1
-    universalify: ^0.2.0
-    url-parse: ^1.5.3
-  checksum: c9226afff36492a52118432611af083d1d8493a53ff41ec4ea48e5b583aec744b989e4280bcf476c910ec1525a89a4a0f1cae81c08b18fb2ec3a9b3a72b91dcc
   languageName: node
   linkType: hard
 
@@ -7001,13 +6944,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"universalify@npm:^0.2.0":
-  version: 0.2.0
-  resolution: "universalify@npm:0.2.0"
-  checksum: e86134cb12919d177c2353196a4cc09981524ee87abf621f7bc8d249dbbbebaec5e7d1314b96061497981350df786e4c5128dbf442eba104d6e765bc260678b5
-  languageName: node
-  linkType: hard
-
 "update-browserslist-db@npm:^1.0.11":
   version: 1.0.11
   resolution: "update-browserslist-db@npm:1.0.11"
@@ -7019,16 +6955,6 @@ __metadata:
   bin:
     update-browserslist-db: cli.js
   checksum: b98327518f9a345c7cad5437afae4d2ae7d865f9779554baf2a200fdf4bac4969076b679b1115434bd6557376bdd37ca7583d0f9b8f8e302d7d4cc1e91b5f231
-  languageName: node
-  linkType: hard
-
-"url-parse@npm:^1.5.3":
-  version: 1.5.10
-  resolution: "url-parse@npm:1.5.10"
-  dependencies:
-    querystringify: ^2.1.1
-    requires-port: ^1.0.0
-  checksum: fbdba6b1d83336aca2216bbdc38ba658d9cfb8fc7f665eb8b17852de638ff7d1a162c198a8e4ed66001ddbf6c9888d41e4798912c62b4fd777a31657989f7bdf
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
This pull request aims to enhance the handling of the `accept-language` header in the codebase. The current implementation hardcodes the language to `ko` (Korean), which can potentially cause issues in the future and make the library more detectable. To address this, I have made the following changes:

1. Utilized the cross-platform `Intl` namespace [learn more here](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Intl), which is built into the Node.js, Deno, and Browser runtimes, to retrieve the preferred language setting from the device or server where the code is running.
2. Exposed the language setting as a configurable option, allowing users to manually set the desired language if needed.

These changes improve the flexibility and future-proofing of the library by dynamically determining the language based on the device's (runtime's) preferred settings.