### PR TITLE
User Feed Queries for Logged in Users - Pagination!

### DIFF
--- a/threads-api/src/threads-api.ts
+++ b/threads-api/src/threads-api.ts
@@ -10,9 +10,9 @@ import {
   BASE_API_URL,
   LOGIN_EXPERIMENTS,
   SIGNATURE_KEY,
-} from './constants';import { LATEST_ANDROID_APP_VERSION } from './dynamic-data';
+} from './constants';
+import { LATEST_ANDROID_APP_VERSION } from './dynamic-data';
 import { Extensions, Thread, ThreadsUser } from './threads-types';
-
 
 export type AndroidDevice = {
   manufacturer: string;

--- a/threads-api/src/threads-api.ts
+++ b/threads-api/src/threads-api.ts
@@ -2,8 +2,15 @@ import axios, { AxiosRequestConfig } from 'axios';
 import * as crypto from 'crypto';
 import mimeTypes from 'mrmime';
 import { v4 as uuidv4 } from 'uuid';
-import { POST_URL, POST_WITH_IMAGE_URL, DEFAULT_LSD_TOKEN, DEFAULT_DEVICE_ID, BASE_API_URL, LOGIN_EXPERIMENTS, SIGNATURE_KEY } from './constants';
-import { LATEST_ANDROID_APP_VERSION } from './dynamic-data';
+import {
+  POST_URL,
+  POST_WITH_IMAGE_URL,
+  DEFAULT_LSD_TOKEN,
+  DEFAULT_DEVICE_ID,
+  BASE_API_URL,
+  LOGIN_EXPERIMENTS,
+  SIGNATURE_KEY,
+} from './constants';import { LATEST_ANDROID_APP_VERSION } from './dynamic-data';
 import { Extensions, Thread, ThreadsUser } from './threads-types';
 
 

--- a/threads-api/src/threads-api.ts
+++ b/threads-api/src/threads-api.ts
@@ -543,8 +543,6 @@ export class ThreadsAPI {
     return threads;
   };
 
-  // Supports pagination
-  // nextCursor returns null if no more posts
   getUserProfileThreadsLoggedIn: PaginationUserIDQuerier<{
     threads: Thread[];
     nextCursor?: string;
@@ -596,8 +594,6 @@ export class ThreadsAPI {
     return threads;
   };
 
-  // Supports pagination
-  // nextCursor returns null if no more posts
   getUserProfileRepliesLoggedIn: PaginationUserIDQuerier<{
     threads: Thread[];
     nextCursor?: string;

--- a/threads-api/src/threads-api.ts
+++ b/threads-api/src/threads-api.ts
@@ -602,9 +602,9 @@ export class ThreadsAPI {
     userID,
     maxID = '',
     options = {},
-  ): Promise<{ threads: Thread[]; nextMaxID?: string | null; error?: string }> => {
+  ): Promise<{ threads: Thread[]; nextCursor?: string; success: boolean; error?: string }> => {
     if (!this.token) {
-      return { error: 'Not logged in.', threads: [] };
+      return { success: false, error: 'Not logged in.', threads: [] };
     }
 
     const result = await axios.get(
@@ -619,10 +619,10 @@ export class ThreadsAPI {
     );
 
     if (result.data.status !== 'ok') {
-      return { error: result.data.error_title, threads: [] };
+      return { success: false, error: result.data.error_title, threads: [] };
     }
 
-    return { threads: result.data.threads, nextMaxID: result.data.next_max_id };
+    return { success: true, threads: result.data.threads, nextCursor: result.data.next_max_id };
   };
 
   getPostIDfromThreadID = async (

--- a/threads-api/src/threads-api.ts
+++ b/threads-api/src/threads-api.ts
@@ -2,17 +2,10 @@ import axios, { AxiosRequestConfig } from 'axios';
 import * as crypto from 'crypto';
 import mimeTypes from 'mrmime';
 import { v4 as uuidv4 } from 'uuid';
-import {
-  POST_URL,
-  POST_WITH_IMAGE_URL,
-  DEFAULT_LSD_TOKEN,
-  DEFAULT_DEVICE_ID,
-  BASE_API_URL,
-  LOGIN_EXPERIMENTS,
-  SIGNATURE_KEY,
-} from './constants';
+import { POST_URL, POST_WITH_IMAGE_URL, DEFAULT_LSD_TOKEN, DEFAULT_DEVICE_ID, BASE_API_URL, LOGIN_EXPERIMENTS, SIGNATURE_KEY } from './constants';
 import { LATEST_ANDROID_APP_VERSION } from './dynamic-data';
 import { Extensions, Thread, ThreadsUser } from './threads-types';
+
 
 export type AndroidDevice = {
   manufacturer: string;
@@ -356,6 +349,10 @@ export class ThreadsAPI {
     'User-Agent': `Barcelona ${LATEST_ANDROID_APP_VERSION} Android`,
     'Content-Type': 'application/x-www-form-urlencoded; charset=UTF-8',
     ...(this.token && { Authorization: `Bearer IGT:2:${this.token}` }),
+  });
+
+  _getInstaHeaders = () => ({
+    ...this._getAppHeaders(),
     ...(this.userID && { 'Ig-U-Ds-User-Id': this.userID, 'Ig-Intended-User-Id': this.userID }),
   });
 
@@ -560,7 +557,7 @@ export class ThreadsAPI {
       {
         ...options,
         headers: {
-          ...this._getAppHeaders(),
+          ...this._getInstaHeaders(),
           ...options?.headers,
         },
       },
@@ -612,7 +609,7 @@ export class ThreadsAPI {
       {
         ...options,
         headers: {
-          ...this._getAppHeaders(),
+          ...this._getInstaHeaders(),
           ...options?.headers,
         },
       },


### PR DESCRIPTION
This PR implements the calls made within the app to populate a user's threads and replies.

The big thing here is that it supports **PAGINATION** using instagram's `max_id` query param (renamed to `cursor`)

Please rip this PR apart if there is a better way you'd prefer for this type of implementation! ❤️