### PR TITLE
🔏 Add support for .env config out of the box

### DIFF
--- a/package.json
+++ b/package.json
@@ -12,5 +12,8 @@
     "@trivago/prettier-plugin-sort-imports": "^4.1.1",
     "prettier": "^2.8.0"
   },
-  "packageManager": "yarn@3.6.1"
+  "packageManager": "yarn@3.6.1",
+  "dependencies": {
+    "dotenv": "^16.3.1"
+  }
 }

--- a/threads-api/src/threads-api.ts
+++ b/threads-api/src/threads-api.ts
@@ -1,5 +1,6 @@
 import axios, { AxiosRequestConfig } from 'axios';
 import * as crypto from 'crypto';
+import 'dotenv/config';
 import mimeTypes from 'mrmime';
 import { v4 as uuidv4 } from 'uuid';
 import {
@@ -166,10 +167,20 @@ export class ThreadsAPI {
     this.httpAgent = options?.httpAgent;
     this.httpsAgent = options?.httpsAgent;
 
-    this.username = options?.username;
-    this.password = options?.password;
+    this.username = options?.username ?? process.env.THREADS_USERNAME;
+    this.password = options?.password ?? process.env.THREADS_PASSWORD;
 
     if (options?.deviceID) this.deviceID = options.deviceID;
+    if (process.env.THREADS_DEVICE_ID) this.deviceID = process.env.THREADS_DEVICE_ID;
+
+    if (options?.deviceID ?? process.env.THREADS_DEVICE_ID) {
+      console.warn(
+        `⚠️ WARNING: deviceID not provided, automatically generating device id '${this.deviceID}'`,
+        'Please save this device id and use it for future uses to prevent login issues.',
+        'You can provide this device id by passing it to the constructor or setting the THREADS_DEVICE_ID environment variable (.env file)',
+      );
+    }
+
     this.device = options?.device;
     this.userID = options?.userID;
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -6441,6 +6441,7 @@ __metadata:
   resolution: "threads-api-project@workspace:."
   dependencies:
     "@trivago/prettier-plugin-sort-imports": ^4.1.1
+    dotenv: ^16.3.1
     prettier: ^2.8.0
   languageName: unknown
   linkType: soft


### PR DESCRIPTION
This pull request adds built-in support for reading `.env` configuration files so users can safely pass in their usernames, passwords, and device identifiers without hardcoding them.

The order of precedence is:

- Values passed in the constructor will override `.env`
- `.env` will override defaults

### Supported `.env` values

Out of the box, the following `.env` values are supported:

- `THREAD_USERNAME` - Thread/Instagram username 
- `THREAD_PASSWORD` - Thread/Instagram password
- `THREAD_DEVICE_ID` - Device ID for requests