### PR TITLE
Updated README.md to fix issue with details block

### DIFF
--- a/threads-api/README.md
+++ b/threads-api/README.md
@@ -55,6 +55,7 @@ const main = async () => {
 };
 main();
 ```
+</details>
 
 #### Auth Required
 
@@ -203,7 +204,6 @@ await new Promise((resolve) => setTimeout(resolve, 5_000));
 await threadsAPI.delete(postID);
 ```
 
-<details>
   <summary>
     <h3>Old API (Deprecated, Still works for backwards compatibility)</h3>
   </summary>
@@ -235,7 +235,7 @@ const threadsAPI = new ThreadsAPI({
 });
 ```
 
-</details>
+</>
 
 ## [<img src="https://github.com/junhoyeo/threads-api/raw/main/.github/emojis/package.png" width="30" height="30" />](https://github.com/junhoyeo) Installation
 


### PR DESCRIPTION
The details block ending tag had been placed incorrectly, such that none of the README contents were showing correctly.