### PR TITLE
[api] Statically get Post ID with base64 encoding

### DIFF
--- a/threads-api/README.md
+++ b/threads-api/README.md
@@ -39,7 +39,7 @@ const main = async () => {
   console.log(JSON.stringify(replies));
 
   // 📖 Details for a specific thread
-  const postID = await threadsAPI.getPostIDfromURL(
+  const postID = threadsAPI.getPostIDfromURL(
     'https://www.threads.net/t/CuX_UYABrr7/?igshid=MzRlODBiNWFlZA==',
   );
   // or use `threadsAPI.getPostIDfromThreadID('CuX_UYABrr7')`
@@ -134,7 +134,7 @@ await threadsAPI.publish({
 
 ```ts
 const parentURL = 'https://www.threads.net/t/CugF-EjhQ3r';
-const parentPostID = await threadsAPI.getPostIDfromURL(parentURL); // or use `getPostIDfromThreadID`
+const parentPostID = threadsAPI.getPostIDfromURL(parentURL); // or use `getPostIDfromThreadID`
 
 await threadsAPI.publish({
   text: '🤖 Beep',
@@ -153,7 +153,7 @@ await threadsAPI.publish({
 
 ```ts
 const threadURL = 'https://www.threads.net/t/CuqbBI8h19H';
-const postIDToQuote = await threadsAPI.getPostIDfromURL(threadURL); // or use `getPostIDfromThreadID`
+const postIDToQuote = threadsAPI.getPostIDfromURL(threadURL); // or use `getPostIDfromThreadID`
 
 await threadsAPI.publish({
   text: '🤖 Quote a Thread',
@@ -165,7 +165,7 @@ await threadsAPI.publish({
 
 ```ts
 const threadURL = 'https://www.threads.net/t/CugK35fh6u2';
-const postIDToLike = await threadsAPI.getPostIDfromURL(threadURL); // or use `getPostIDfromThreadID`
+const postIDToLike = threadsAPI.getPostIDfromURL(threadURL); // or use `getPostIDfromThreadID`
 
 // 💡 Uses current credentials
 await threadsAPI.like(postIDToLike);
@@ -186,7 +186,7 @@ await threadsAPI.unfollow(userIDToFollow);
 
 ```ts
 const threadURL = 'https://www.threads.net/t/CugK35fh6u2';
-const postIDToRepost = await threadsAPI.getPostIDfromURL(threadURL); // or use `getPostIDfromThreadID`
+const postIDToRepost = threadsAPI.getPostIDfromURL(threadURL); // or use `getPostIDfromThreadID`
 
 // 💡 Uses current credentials
 await threadsAPI.repost(postIDToRepost);

--- a/threads-api/__test__/getPostIDfromThreadID.test.ts
+++ b/threads-api/__test__/getPostIDfromThreadID.test.ts
@@ -11,7 +11,7 @@ describe('getPostIDfromThreadID', () => {
       const threadID = 'CuX_UYABrr7';
 
       // when
-      postID = await threadsAPI.getPostIDfromThreadID(threadID);
+      postID = threadsAPI.getPostIDfromThreadID(threadID);
     });
 
     it('should return postID', async () => {

--- a/threads-api/__test__/getPostIDfromURL.test.ts
+++ b/threads-api/__test__/getPostIDfromURL.test.ts
@@ -11,7 +11,7 @@ describe('getPostIDfromURL', () => {
       const postURL = 'https://www.threads.net/t/CuX_UYABrr7/?igshid=MzRlODBiNWFlZA==';
 
       // when
-      postID = await threadsAPI.getPostIDfromURL(postURL);
+      postID = threadsAPI.getPostIDfromURL(postURL);
     });
 
     it('should return postID', async () => {

--- a/threads-api/__test__/interaction-like-and-unlike.test.ts
+++ b/threads-api/__test__/interaction-like-and-unlike.test.ts
@@ -15,7 +15,7 @@ describeIf(!!credentials)('Like/Unlike', () => {
 
       // given
       const threadURL = 'https://www.threads.net/t/CugDXa1hMza';
-      const postID = (await threadsAPI.getPostIDfromURL(threadURL)) || '';
+      const postID = threadsAPI.getPostIDfromURL(threadURL) || '';
 
       // like
       await new Promise((resolve) => setTimeout(resolve, 1_000)); // delay for safety


### PR DESCRIPTION
- Fixes #149 (https://github.com/junhoyeo/threads-api/issues/149#issuecomment-1636198187)
- https://github.com/junhoyeo/threads-py/pull/27
- Note: we need to use `bigint` to handle arbitrary large integers