### PR TITLE
fix: strip user ID from parentPostID and quotedPostID

### DIFF
--- a/threads-api/src/threads-api.ts
+++ b/threads-api/src/threads-api.ts
@@ -993,10 +993,12 @@ export class ThreadsAPI {
     }
 
     if (!!options.parentPostID) {
-      data.text_post_app_info.reply_id = options.parentPostID;
+      // Ensure no user ID is included in the parent post ID.
+      data.text_post_app_info.reply_id = options.parentPostID.replace(/_\d+$/, '');
     }
     if (!!options.quotedPostID) {
-      data.text_post_app_info.quoted_post_id = options.quotedPostID;
+      // Ensure no user ID is included in the quoted post ID.
+      data.text_post_app_info.quoted_post_id = options.quotedPostID.replace(/_\d+$/, '');
     }
     if (!(options as any).image) {
       data.publish_mode = 'text_post';


### PR DESCRIPTION
The post ID returned by `publish` includes the user ID at the end (e.g. `3148420376389470708_60654468808`), which is fine, but the `publish` endpoint expects `reply_id` and `quoted_post_id` to not have the user ID part (e.g. `3148420376389470708` only).

Fixes https://github.com/junhoyeo/threads-api/issues/149#issue-1803468082