### PR TITLE
postId from publish

### DIFF
--- a/threads-api/src/threads-api.ts
+++ b/threads-api/src/threads-api.ts
@@ -1028,7 +1028,7 @@ export class ThreadsAPI {
     }
 
     if (res.data['status'] === 'ok') {
-      return res.data['media']['id'];
+      return res.data['media']['id'].replace(/_\d+$/, '');
     }
 
     return undefined;


### PR DESCRIPTION
Only return the published postId when doing `publish()`