### PR TITLE
[web-ui] Workaround for overflow: hidden + border-radius bug in Safari

### DIFF
--- a/threads-web-ui/app/page.tsx
+++ b/threads-web-ui/app/page.tsx
@@ -26,7 +26,13 @@ export default async function Home() {
             </p>
           </header>
 
-          <div className="bg-[rgba(243,245,247,0.15) w-[200px] h-[200px] rounded-[32px] overflow-hidden">
+          <div
+            className="bg-[rgba(243,245,247,0.15) w-[200px] h-[200px] rounded-[32px] overflow-hidden"
+            style={{
+              transform: 'translateZ(0)',
+              willChange: 'transform',
+            }}
+          >
             <div
               className="w-[200px] h-[200px] flex items-center justify-center backdrop-blur-sm"
               style={{


### PR DESCRIPTION
| Before | After |
|:---:|:---:|
| <img width="313" alt="Screenshot 2023-07-18 at 4 26 36 AM" src="https://github.com/junhoyeo/threads-api/assets/32605822/730f7e80-74e7-4f3d-8798-b271873e5ebe"> | <img width="314" alt="Screenshot 2023-07-18 at 4 26 23 AM" src="https://github.com/junhoyeo/threads-api/assets/32605822/66284f3f-02b5-410b-96ed-d1677ec148d7"> |