### PR TITLE
fix: broken type import

### DIFF
--- a/threads-api/src/threads-api.ts
+++ b/threads-api/src/threads-api.ts
@@ -4,7 +4,6 @@ import 'dotenv/config';
 import * as mimeTypes from 'mrmime';
 import { v4 as uuidv4 } from 'uuid';
 
-import { StrictUnion } from 'types/utils';
 import {
   BASE_API_URL,
   BASE_FOLLOW_PARAMS,
@@ -21,6 +20,7 @@ import {
 } from './constants';
 import { LATEST_ANDROID_APP_VERSION } from './dynamic-data';
 import { AndroidDevice, Extensions, Thread, ThreadsUser } from './threads-types';
+import { StrictUnion } from './types/utils';
 
 const generateDeviceID = () => `android-${(Math.random() * 1e24).toString(36)}`;
 


### PR DESCRIPTION
The "types/utils" specifier cannot be resolved when this package is installed from NPM, since it is provided by tsconfig baseUrl option.