### PR TITLE
fix(api): dotenv config was invoked explicitly

### DIFF
--- a/threads-api/src/threads-api.ts
+++ b/threads-api/src/threads-api.ts
@@ -1,6 +1,5 @@
 import axios, { AxiosRequestConfig } from 'axios';
 import * as crypto from 'crypto';
-import 'dotenv/config';
 import * as mimeTypes from 'mrmime';
 import { v4 as uuidv4 } from 'uuid';
 


### PR DESCRIPTION
Loading `dotenv` configurations should be performed by the consumer codebases of the api.

I don't think there is a need to call it here.

Resolves #233