### PR TITLE
api: Move `dotenv` to devDependencies

### DIFF
--- a/threads-api/package.json
+++ b/threads-api/package.json
@@ -37,6 +37,7 @@
     "@types/uuid": "^9.0.2",
     "babel-jest": "^29.6.1",
     "commander": "^11.0.0",
+    "dotenv": "^16.3.1",
     "jest": "^29.6.1",
     "rimraf": "^5.0.1",
     "ts-jest": "^29.1.1",
@@ -45,7 +46,6 @@
   },
   "dependencies": {
     "axios": "^1.4.0",
-    "dotenv": "^16.3.1",
     "mrmime": "^1.0.1",
     "uuid": "^9.0.0"
   },


### PR DESCRIPTION
Closes #240, Related to #235